### PR TITLE
Remove retry_join for Azure

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -192,7 +192,7 @@ resource "azurerm_linux_virtual_machine" "server" {
       region                    = var.location
       cloud_env                 = "azure"
       server_count              = "${var.server_count}"
-      retry_join                = var.retry_join
+      retry_join                = "provider=azure tag_name=NomadJoinTag tag_value=auto-join subscription_id=${var.subscription_id} tenant_id=${var.tenant_id} client_id=${var.client_id} secret_access_key=${var.client_secret}"
       nomad_version             = var.nomad_version
   }))}"
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -17,6 +17,10 @@ provider "azurerm" {
   tenant_id = var.tenant_id
 }
 
+locals {
+  retry_join = "provider=azure tag_name=NomadJoinTag tag_value=auto-join subscription_id=${var.subscription_id} tenant_id=${var.tenant_id} client_id=${var.client_id} secret_access_key=${var.client_secret}"
+}
+
 resource "tls_private_key" "private_key" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -192,7 +196,7 @@ resource "azurerm_linux_virtual_machine" "server" {
       region                    = var.location
       cloud_env                 = "azure"
       server_count              = "${var.server_count}"
-      retry_join                = "provider=azure tag_name=NomadJoinTag tag_value=auto-join subscription_id=${var.subscription_id} tenant_id=${var.tenant_id} client_id=${var.client_id} secret_access_key=${var.client_secret}"
+      retry_join                = local.retry_join
       nomad_version             = var.nomad_version
   }))}"
 }
@@ -268,7 +272,7 @@ resource "azurerm_linux_virtual_machine" "client" {
   custom_data    = "${base64encode(templatefile("../shared/data-scripts/user-data-client.sh", {
       region                    = var.location
       cloud_env                 = "azure"
-      retry_join                = var.retry_join
+      retry_join                = local.retry_join
       nomad_version             = var.nomad_version
   }))}"
 }

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -7,8 +7,6 @@ client_secret = "CLIENT_SECRET"
 resource_group_name = "RESOURCE_GROUP_NAME"
 storage_account = "STORAGE_ACCOUNT_NAME"
 
-retry_join = "provider=azure tag_name=NomadJoinTag tag_value=auto-join subscription_id=SUBSCRIPTION_ID tenant_id=TENANT_ID client_id=CLIENT_ID secret_access_key=CLIENT_SECRET"
-
 # These variables will default to the values shown
 # and do not need to be updated unless you want to
 # change them

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -17,15 +17,11 @@ variable "client_id" {
 
 variable "client_secret" {
   description = "The Azure client secret to use."
+  sensitive = true
 }
 
 variable "tenant_id" {
   description = "The Azure tenant ID to use."
-}
-
-variable "retry_join" {
-  description = "Used by Nomad to automatically form a cluster."
-  type        = string
 }
 
 variable "allowlist_ip" {


### PR DESCRIPTION
- This PR removes the `retry_join` for the Azure example and creates it in the terraform file using interpolation. It feels like this is just an extra step which can be removed.
- Also, changed the variable type for `client_secret` to sensitive.