### PR TITLE
(fix) use network_mode host for Docker driver

### DIFF
--- a/jobs/pytechco-employee.nomad.hcl
+++ b/jobs/pytechco-employee.nomad.hcl
@@ -36,6 +36,7 @@ EOH
         // args = [
         //     "--employee-type", "sales_engineer"
         // ]
+        network_mode = "host"
       }
     }
   }

--- a/jobs/pytechco-setup.nomad.hcl
+++ b/jobs/pytechco-setup.nomad.hcl
@@ -25,6 +25,7 @@ EOH
 
       config {
         image = "ghcr.io/hashicorp-education/learn-nomad-getting-started/ptc-setup:1.0"
+        network_mode = "host"
       }
     }
   }

--- a/jobs/pytechco-web.nomad.hcl
+++ b/jobs/pytechco-web.nomad.hcl
@@ -34,6 +34,7 @@ EOH
       config {
         image = "ghcr.io/hashicorp-education/learn-nomad-getting-started/ptc-web:1.0"
         ports = ["web"]
+        network_mode = "host"
       }
     }
   }


### PR DESCRIPTION
This is because the configuration causes the application to try to reach out to the local host (127.0.0.1) but the Docker driver defaults to bridge mode. By explicitly defining host in the config we can reach the redis instance.

I don't know if this was intentional, or a misconfiguration of my setup, but out of the box the examples don't seem to work :)