### PR TITLE
Bump AWS Ubuntu AMI to 22.04 LTS

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -130,7 +130,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
I don't believe Ubuntu 16.04 is a supported AMI by Canonical any longer. In `us-east-2` at least, the current example fails to look up this version of the AMI

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Your query returned no results. Please change your search criteria and try again.
│
│   with data.aws_ami.ubuntu,
│   on main.tf line 127, in data "aws_ami" "ubuntu":
│  127: data "aws_ami" "ubuntu" {
```

24.04 LTS was also recently released, so that may be a better candidate though.

Fixes #8
Fixes #10 
