### PR TITLE
Enable br_netfilter kernel module

### DIFF
--- a/shared/data-scripts/user-data-client.sh
+++ b/shared/data-scripts/user-data-client.sh
@@ -85,6 +85,8 @@ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/relea
 sudo mkdir -p /opt/cni/bin
 sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 
+sudo modprobe br_netfilter
+
 echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables


### PR DESCRIPTION
The user-data was failing as the /proc/sys/net/bridge directory didn't exist.

Enabling br_netfilter module creates the directory.